### PR TITLE
adding badges to readme.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,9 +1,10 @@
 DanaSwapUI
 ==========
-image:https://img.shields.io/badge/ci--by--hercules-green.svg["Hercules continuous integration status for all DanaSwapUI front-ends", link="https://hercules-ci.com/github/ArdanaLabs/DanaSwapUI"]
-image:https://img.shields.io/badge/cachix-private_ArdanaLabs-blue.svg["Cachix provisioning of binary builds",link="https://private-ardanalabs.cachix.org"]
 
 Ardana application’s front-end web platforms
+
+image:https://img.shields.io/badge/ci--by--hercules-green.svg["Hercules continuous integration status for all DanaSwapUI front-ends", link="https://hercules-ci.com/github/ArdanaLabs/DanaSwapUI"]
+image:https://img.shields.io/badge/cachix-private_ArdanaLabs-blue.svg["Cachix provisioning of binary builds",link="https://private-ardanalabs.cachix.org"]
 
 NOTE: This looks like a monorepo, but doesn’t quack like one. Without
 workspace support for `dream2nix`, this should likely be split out into


### PR DESCRIPTION
This applies the addition of CI-integration badges to the readme file; allowing people to click links to reach Hercules and cachix