### PR TITLE
Non-CSP security header + theme color

### DIFF
--- a/frontend-dashboard/public/index.html
+++ b/frontend-dashboard/public/index.html
@@ -2,9 +2,18 @@
 <html lang="en-US">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
+
+    <meta http-equiv="X-XSS-Protection" content="1;mode=block" />
+    <meta http-equiv="X-Content-Type-Options" content="nosniff" />
+    <meta
+      http-equiv="Referrer-Policy"
+      content="strict-origin-when-cross-origin"
+    />
+    <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <meta name="theme-color" content="#235DF4" />
     <meta
       name="description"
       content="Ardana is a decentralized exchange stable asset liquidity pool and on-chain asset backed stablecoin protocol built on Cardano."

--- a/frontend-landing/public/index.html
+++ b/frontend-landing/public/index.html
@@ -2,9 +2,18 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
+
+    <meta http-equiv="X-XSS-Protection" content="1;mode=block" />
+    <meta http-equiv="X-Content-Type-Options" content="nosniff" />
+    <meta
+      http-equiv="Referrer-Policy"
+      content="strict-origin-when-cross-origin"
+    />
+    <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <meta name="theme-color" content="#235DF4" />
     <meta
       name="description"
       content="Ardana is a decentralized exchange stable asset liquidity pool and on-chain asset backed stablecoin protocol built on Cardano."


### PR DESCRIPTION
Because GitHub issue #45 needed to be reverted due to the CSP failing
and it being hard to test while we don’t have a staging environment,
moving these features to a separate merge request

https://owasp.org/www-project-secure-headers/

* Security headers
  * XSS-Protection
  * Content-type-options: nosniff
  * referrer policy
* Opting out of Google’s FLoC
  * EFF: https://www.eff.org/deeplinks/2021/03/googles-floc-terrible-idea
  * Mozilla: https://blog.mozilla.org/en/privacy-security/privacy-analysis-of-floc/
* Theme color set to Ardana blue instead of the default black