### PR TITLE
Add Google lighthouse to flake outputs

### DIFF
--- a/dream2nix-overrides/nodejs/default.nix
+++ b/dream2nix-overrides/nodejs/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  pkgs,
+
+  # dream2nix
+  satisfiesSemver,
+  ...
+}:
+let
+  # The `dist` folder is not included with lighthouse when trying to compile it
+  # from source, and it's not clear how to produce it. So this function fetches
+  # it from the npm registry. Conversely, the lockfile is not included when
+  # fetching from the registry, so this is a hard position to be in. We may be
+  # able to fix this hack in future.
+  getLighthouseDist = version: pkgs.stdenv.mkDerivation {
+    name = "lighthouse-dist";
+    src = pkgs.fetchurl {
+      url = "https://registry.npmjs.org/lighthouse/-/lighthouse-${version}.tgz";
+      sha256 = "sha256-QDjBxZ6ZvGJn6s7eG+/Y2QPXRs3LwnhMMs/z0wzzZfM=";
+    };
+    dontBuild = true;
+    installPhase = ''
+      mv dist $out
+    '';
+  };
+in
+{
+  lighthouse.build = {
+    nativeBuildInputs = old: old ++ [
+      pkgs.makeWrapper
+    ];
+    overrideAttrs = old: {
+      preBuild = ''
+        cp -r ${getLighthouseDist old.version} ./dist
+      '';
+      postInstall = ''
+        wrapProgram $out/bin/lighthouse \
+          --set CHROME_PATH "${pkgs.chromium}/bin/chromium"
+        wrapProgram $out/bin/smokehouse \
+          --set CHROME_PATH "${pkgs.chromium}/bin/chromium"
+        wrapProgram $out/bin/chrome-debug \
+          --set CHROME_PATH "${pkgs.chromium}/bin/chromium"
+      '';
+    };
+  };
+  puppeteer.build = {
+    PUPPETEER_SKIP_DOWNLOAD = true;
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -221,6 +221,23 @@
         "type": "github"
       }
     },
+    "lighthouse-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1646875274,
+        "narHash": "sha256-M2YepfUlxytNGfbQHdzxj7q1frwjRSyQAGZ1SGRRyR0=",
+        "owner": "GoogleChrome",
+        "repo": "lighthouse",
+        "rev": "ff52c9d56107695b30419ce453d3ba6da1cff632",
+        "type": "github"
+      },
+      "original": {
+        "owner": "GoogleChrome",
+        "ref": "v9.5.0",
+        "repo": "lighthouse",
+        "type": "github"
+      }
+    },
     "mach-nix": {
       "flake": false,
       "locked": {
@@ -428,6 +445,7 @@
         "flake-compat": "flake-compat",
         "flake-compat-ci": "flake-compat-ci",
         "hercules-ci-effects": "hercules-ci-effects",
+        "lighthouse-src": "lighthouse-src",
         "nixpkgs": "nixpkgs_3"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -11,9 +11,13 @@
       flake = false;
     };
     hercules-ci-effects.url = "github:hercules-ci/hercules-ci-effects";
+    lighthouse-src = {
+      url = "github:GoogleChrome/lighthouse/v9.5.0";
+      flake = false;
+    };
   };
 
-  outputs = { self, nixpkgs, flake-compat, flake-compat-ci, dream2nix, hercules-ci-effects }@inputs:
+  outputs = { self, nixpkgs, flake-compat, flake-compat-ci, dream2nix, hercules-ci-effects, lighthouse-src }@inputs:
     let
 
       # Generate a user-friendly version number.
@@ -31,7 +35,7 @@
       dream2nix = inputs.dream2nix.lib2.init {
         systems = supportedSystems;
         config = {
-          overridesDirs = [ "${inputs.dream2nix}/overrides" ];
+          overridesDirs = [ "${inputs.dream2nix}/overrides" ./dream2nix-overrides ];
           projectRoot = ./.;
         };
       };
@@ -164,6 +168,9 @@
         frontend-vault = (dream2nix.makeFlakeOutputs {
           source = ./frontend-vault;
         }).packages.${system}.ardana-vault;
+        lighthouse = (dream2nix.makeFlakeOutputs {
+          source = lighthouse-src;
+        }).packages.${system}.lighthouse;
       });
 
       devShell = forAllSystems (system:


### PR DESCRIPTION
This is a tool made by Google which is usually embedded in the chrome
browser. It will generate reports for us, which will allow us to cause
CI to fail if the website performance goes below a certain value.